### PR TITLE
Updated credentials for braintree cardinal 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,10 +17,10 @@ rootProject.allprojects {
         google()
         jcenter()
         maven {
-            url "https://cardinalcommerce.bintray.com/android"
+            url "https://cardinalcommerceprod.jfrog.io/artifactory/android"
             credentials {
-                username 'braintree-team-sdk@cardinalcommerce'
-                password '220cc9476025679c4e5c843666c27d97cfb0f951'
+                username 'braintree_team_sdk'
+                password 'AKCp8jQcoDy2hxSWhDAUQKXLDPDx6NYRkqrgFLRc3qDrayg6rrCbJpsKKyMwaykVL8FWusJpp'
             }
         }
     }


### PR DESCRIPTION
This change is in accordance to the official [`braintree_android`](https://github.com/braintree/braintree_android) package.
For more details regarding the issue, check this [braintree/braintree_android#373 (comment)](https://github.com/braintree/braintree_android/issues/373#issue-873084089)