### PR TITLE
Fixed issue with ApplePay pod install

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -28,6 +28,8 @@ PODS:
     - Braintree/Venmo (>= 5.3.2, ~> 5.3)
   - Flutter (1.0.0)
   - flutter_braintree (1.0.0):
+    - Braintree/ApplePay (~> 5.3.2)
+    - Braintree/PayPal (~> 5.3.2)
     - BraintreeDropIn (= 9.0.2)
     - Flutter
 
@@ -50,7 +52,7 @@ SPEC CHECKSUMS:
   Braintree: d9314d1a97acda74b77e40be5db6aa3e655c6539
   BraintreeDropIn: 3e666d341e34efb0b5e18221eacd76db469bdab8
   Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
-  flutter_braintree: ddfc21f676d68a0658d72ac00fffb172216a0e23
+  flutter_braintree: fe1bf2f5e99010e293af6986bc55876362bb28dd
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -87,7 +87,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:

--- a/ios/flutter_braintree.podspec
+++ b/ios/flutter_braintree.podspec
@@ -16,8 +16,8 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'BraintreeDropIn', '9.0.2'
-  s.dependency 'Braintree/PayPal', '~> 5.0.0'
-  s.dependency 'Braintree/Apple-Pay', '~> 5.0.0'
+  s.dependency 'Braintree/PayPal', '~> 5.3.2'
+  s.dependency 'Braintree/ApplePay', '~> 5.3.2'
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.0'
 end

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -26,7 +26,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.3.0"
   sky_engine:
     dependency: transitive
     description: flutter


### PR DESCRIPTION
Braintree ApplePay was changed from Braintree/Apple-Pay to Braintree/ApplePay which was causing an error when you try to build for iOS

```
[!] CocoaPods could not find compatible versions for pod "Braintree/Apple-Pay":
  In Podfile:
    flutter_braintree (from `.symlinks/plugins/flutter_braintree/ios`) was resolved to 1.0.0, which depends on
      Braintree/Apple-Pay (~> 5.0.0)

None of your spec sources contain a spec satisfying the dependency: Braintree/Apple-Pay (~> 5.0.0).

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.
 ```

This PR fixes that