### PR TITLE
Added PayPal Payer Id

### DIFF
--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeCustom.java
@@ -15,6 +15,7 @@ import com.braintreepayments.api.interfaces.PaymentMethodNonceCreatedListener;
 import com.braintreepayments.api.models.CardBuilder;
 import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.PaymentMethodNonce;
+import com.braintreepayments.api.models.PayPalAccountNonce;
 
 import java.util.HashMap;
 
@@ -79,6 +80,10 @@ public class FlutterBraintreeCustom extends AppCompatActivity implements Payment
         nonceMap.put("typeLabel", paymentMethodNonce.getTypeLabel());
         nonceMap.put("description", paymentMethodNonce.getDescription());
         nonceMap.put("isDefault", paymentMethodNonce.isDefault());
+        if (paymentMethodNonce instanceof PayPalAccountNonce) {
+            PayPalAccountNonce paypalAccountNonce = (PayPalAccountNonce) paymentMethodNonce;
+            nonceMap.put("paypalPayerId", paypalAccountNonce.getPayerId());
+        }
 
         Intent result = new Intent();
         result.putExtra("type", "paymentMethodNonce");

--- a/ios/Classes/BaseFlutterBraintreePlugin.swift
+++ b/ios/Classes/BaseFlutterBraintreePlugin.swift
@@ -25,12 +25,15 @@ open class BaseFlutterBraintreePlugin: NSObject {
     }
 
     internal func buildPaymentNonceDict(nonce: BTPaymentMethodNonce?) -> [String: Any?] {
-        [
-            "nonce": nonce?.nonce,
-            "typeLabel": nonce?.type,
-            "description": nonce?.nonce,
-            "isDefault": nonce?.isDefault
-        ];
+        var dict = [String: Any?]()
+        dict["nonce"] = nonce?.nonce
+        dict["typeLabel"] = nonce?.type
+        dict["description"] = nonce?.nonce
+        dict["isDefault"] = nonce?.isDefault
+        if let paypalNonce = nonce as? BTPayPalAccountNonce {
+            dict["paypalPayerId"] = paypalNonce.payerID
+        }
+        return dict
     }
     
     internal func returnAuthorizationMissingError (result: FlutterResult) {

--- a/lib/src/result.dart
+++ b/lib/src/result.dart
@@ -25,6 +25,7 @@ class BraintreePaymentMethodNonce {
     required this.typeLabel,
     required this.description,
     required this.isDefault,
+    this.paypalPayerId,
   });
 
   factory BraintreePaymentMethodNonce.fromJson(dynamic source) {
@@ -33,6 +34,7 @@ class BraintreePaymentMethodNonce {
       typeLabel: source['typeLabel'],
       description: source['description'],
       isDefault: source['isDefault'],
+      paypalPayerId: source['paypalPayerId'],
     );
   }
 
@@ -48,4 +50,7 @@ class BraintreePaymentMethodNonce {
 
   /// True if this payment method is the default for the current customer, false otherwise.
   final bool isDefault;
+
+  /// PayPal payer id if requesting for paypal nonce
+  final String? paypalPayerId;
 }


### PR DESCRIPTION
While creating Paypal Nonce, Currently there is no way we can get PayPal Payer Id. I have tried to add that in the PaymentMethodResponse.