### PR TITLE
change application behaviour in case it's not BT url (in example)

### DIFF
--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -18,7 +18,7 @@ import Braintree
             return BTAppContextSwitcher.handleOpenURL(url)
         }
         
-        return false
+        return super.application(app, open: url, options:  options);
     }
 
 }


### PR DESCRIPTION
The implementation of the plugin as shown in the example causes problem with Facebook login, cause makes impossibile to login with the facebook webview

Linked to this issue https://github.com/pikaju/flutter-braintree/issues/122
