### PR TITLE
Edit package to follow guidelines for transition to 3ds 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,5 +182,38 @@ if (result != null) {
 }
 ```
 
+To increase the chances of success with 3ds 2.0 challenge is possible to add additional information about the user
+as mentioned in the guide to [Migrate to 3ds 2.0](https://developer.paypal.com/braintree/docs/guides/3d-secure/migration).
+```dart
+var request = BraintreeDropInRequest(
+  clientToken: '<Insert your client token here>',
+  collectDeviceData: true,
+  requestThreeDSecureVerification: true,
+  email: "test@email.com",
+  amount: "0,01",
+  billingAddress: BraintreeBillingAddress(
+    givenName: "Jill",
+    surname: "Doe",
+    phoneNumber: "5551234567",
+    streetAddress: "555 Smith St",
+    extendedAddress: "#2",
+    locality: "Chicago",
+    region: "IL",
+    postalCode: "12345",
+    countryCodeAlpha2: "US",
+  ),
+  googlePaymentRequest: BraintreeGooglePaymentRequest(
+    totalPrice: '4.20',
+    currencyCode: 'USD',
+    billingAddressRequired: false,
+  ),
+  paypalRequest: BraintreePayPalRequest(
+    amount: '4.20',
+    displayName: 'Example company',
+  ),
+  cardEnabled: true,
+);
+```
+
 See `BraintreeDropInRequest` and `BraintreeDropInResult` for more documentation.
 

--- a/README.md
+++ b/README.md
@@ -202,15 +202,6 @@ var request = BraintreeDropInRequest(
     postalCode: "12345",
     countryCodeAlpha2: "US",
   ),
-  googlePaymentRequest: BraintreeGooglePaymentRequest(
-    totalPrice: '4.20',
-    currencyCode: 'USD',
-    billingAddressRequired: false,
-  ),
-  paypalRequest: BraintreePayPalRequest(
-    amount: '4.20',
-    displayName: 'Example company',
-  ),
   cardEnabled: true,
 );
 ```

--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeDropIn.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeDropIn.java
@@ -81,27 +81,40 @@ public class FlutterBraintreeDropIn implements FlutterPlugin, ActivityAware, Met
     if (call.method.equals("start")) {
       String clientToken = call.argument("clientToken");
       String tokenizationKey = call.argument("tokenizationKey");
-      ThreeDSecurePostalAddress address = new ThreeDSecurePostalAddress();
-      address.givenName("Jill"); // ASCII-printable characters required, else will throw a validation error
-      address.surname("Doe"); // ASCII-printable characters required, else will throw a validation error
-      address.phoneNumber("5551234567");
-      address.streetAddress("555 Smith St");
-      address.extendedAddress("#2");
-      address.locality("Chicago");
-      address.region("IL");
-      address.postalCode("12345");
-      address.countryCodeAlpha2("US");
-
-// For best results, provide as many additional elements as possible.
-      ThreeDSecureAdditionalInformation additionalInformation = new ThreeDSecureAdditionalInformation();
-      additionalInformation.shippingAddress(address);
 
       ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
+
+
+      // For best results with 3ds 2.0, provide as many additional elements as possible.
+      HashMap<String, String> billingAddress = call.argument("billingAddress");
+      if(billingAddress != null){
+        ThreeDSecurePostalAddress address = new ThreeDSecurePostalAddress();
+        address.givenName(billingAddress.get("givenName")); // ASCII-printable characters required, else will throw a validation error
+        address.surname(billingAddress.get("surname")); // ASCII-printable characters required, else will throw a validation error
+        address.phoneNumber(billingAddress.get("phoneNumber"));
+        address.streetAddress(billingAddress.get("streetAddress"));
+        address.extendedAddress(billingAddress.get("extendedAddress"));
+        address.locality(billingAddress.get("locality"));
+        address.region(billingAddress.get("region"));
+        address.postalCode(billingAddress.get("postalCode"));
+        address.countryCodeAlpha2(billingAddress.get("countryCodeAlpha2"));
+
+        ThreeDSecureAdditionalInformation additionalInformation = new ThreeDSecureAdditionalInformation();
+        additionalInformation.shippingAddress(address);
+        threeDSecureRequest.billingAddress(address);
+        threeDSecureRequest.additionalInformation(additionalInformation);
+      }
+
+
+
       threeDSecureRequest.amount((String) call.argument("amount"));
-      threeDSecureRequest.email((String) call.argument("email"));
-      threeDSecureRequest.billingAddress(address);
+      String email = call.argument("email");
+      if(email != null){
+        threeDSecureRequest.email(email);
+      }
+
       threeDSecureRequest.versionRequested(ThreeDSecureRequest.VERSION_2);
-      threeDSecureRequest.additionalInformation(additionalInformation);
+
 
       DropInRequest dropInRequest = new DropInRequest()
               .collectDeviceData((Boolean) call.argument("collectDeviceData"))

--- a/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeDropIn.java
+++ b/android/src/main/java/com/example/flutter_braintree/FlutterBraintreeDropIn.java
@@ -21,6 +21,9 @@ import com.braintreepayments.api.models.GooglePaymentRequest;
 import com.braintreepayments.api.models.PayPalRequest;
 import com.braintreepayments.api.models.PaymentMethodNonce;
 
+import com.braintreepayments.api.models.ThreeDSecureAdditionalInformation;
+import com.braintreepayments.api.models.ThreeDSecurePostalAddress;
+import com.braintreepayments.api.models.ThreeDSecureRequest;
 import com.google.android.gms.wallet.TransactionInfo;
 import com.google.android.gms.wallet.WalletConstants;
 
@@ -78,12 +81,34 @@ public class FlutterBraintreeDropIn implements FlutterPlugin, ActivityAware, Met
     if (call.method.equals("start")) {
       String clientToken = call.argument("clientToken");
       String tokenizationKey = call.argument("tokenizationKey");
+      ThreeDSecurePostalAddress address = new ThreeDSecurePostalAddress();
+      address.givenName("Jill"); // ASCII-printable characters required, else will throw a validation error
+      address.surname("Doe"); // ASCII-printable characters required, else will throw a validation error
+      address.phoneNumber("5551234567");
+      address.streetAddress("555 Smith St");
+      address.extendedAddress("#2");
+      address.locality("Chicago");
+      address.region("IL");
+      address.postalCode("12345");
+      address.countryCodeAlpha2("US");
+
+// For best results, provide as many additional elements as possible.
+      ThreeDSecureAdditionalInformation additionalInformation = new ThreeDSecureAdditionalInformation();
+      additionalInformation.shippingAddress(address);
+
+      ThreeDSecureRequest threeDSecureRequest = new ThreeDSecureRequest();
+      threeDSecureRequest.amount((String) call.argument("amount"));
+      threeDSecureRequest.email((String) call.argument("email"));
+      threeDSecureRequest.billingAddress(address);
+      threeDSecureRequest.versionRequested(ThreeDSecureRequest.VERSION_2);
+      threeDSecureRequest.additionalInformation(additionalInformation);
+
       DropInRequest dropInRequest = new DropInRequest()
-              .amount((String) call.argument("amount"))
               .collectDeviceData((Boolean) call.argument("collectDeviceData"))
               .requestThreeDSecureVerification((Boolean) call.argument("requestThreeDSecureVerification"))
               .maskCardNumber((Boolean) call.argument("maskCardNumber"))
-              .vaultManager((Boolean) call.argument("vaultManagerEnabled"));
+              .vaultManager((Boolean) call.argument("vaultManagerEnabled"))
+              .threeDSecureRequest(threeDSecureRequest);
 
 
       if (clientToken != null)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,13 +25,13 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.flutter_braintree_example"
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/example/ios/Flutter/Flutter.podspec
+++ b/example/ios/Flutter/Flutter.podspec
@@ -6,12 +6,12 @@
 Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
-  s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.homepage         = 'https://flutter.io'
-  s.license          = { :type => 'MIT' }
+  s.summary          = 'A UI toolkit for beautiful and fast apps.'
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'BSD' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   # Framework linking is handled by Flutter tooling, not CocoaPods.
   # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
   s.vendored_frameworks = 'path/to/nothing'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,36 +1,36 @@
 PODS:
-  - Braintree/ApplePay (5.3.2):
+  - Braintree/ApplePay (5.6.3):
     - Braintree/Core
-  - Braintree/Card (5.3.2):
+  - Braintree/Card (5.6.3):
     - Braintree/Core
-  - Braintree/Core (5.3.2)
-  - Braintree/PaymentFlow (5.3.2):
-    - Braintree/Core
-    - Braintree/PayPalDataCollector
-  - Braintree/PayPal (5.3.2):
+  - Braintree/Core (5.6.3)
+  - Braintree/PaymentFlow (5.6.3):
     - Braintree/Core
     - Braintree/PayPalDataCollector
-  - Braintree/PayPalDataCollector (5.3.2)
-  - Braintree/ThreeDSecure (5.3.2):
+  - Braintree/PayPal (5.6.3):
+    - Braintree/Core
+    - Braintree/PayPalDataCollector
+  - Braintree/PayPalDataCollector (5.6.3)
+  - Braintree/ThreeDSecure (5.6.3):
     - Braintree/Card
     - Braintree/PaymentFlow
-  - Braintree/UnionPay (5.3.2):
+  - Braintree/UnionPay (5.6.3):
     - Braintree/Card
-  - Braintree/Venmo (5.3.2):
+  - Braintree/Venmo (5.6.3):
     - Braintree/Core
-  - BraintreeDropIn (9.0.2):
-    - Braintree/ApplePay (>= 5.3.2, ~> 5.3)
-    - Braintree/Card (>= 5.3.2, ~> 5.3)
-    - Braintree/Core (>= 5.3.2, ~> 5.3)
-    - Braintree/PayPal (>= 5.3.2, ~> 5.3)
-    - Braintree/ThreeDSecure (>= 5.3.2, ~> 5.3)
-    - Braintree/UnionPay (>= 5.3.2, ~> 5.3)
-    - Braintree/Venmo (>= 5.3.2, ~> 5.3)
+  - BraintreeDropIn (9.4.0):
+    - Braintree/ApplePay (~> 5.6.1)
+    - Braintree/Card (~> 5.6.1)
+    - Braintree/Core (~> 5.6.1)
+    - Braintree/PayPal (~> 5.6.1)
+    - Braintree/ThreeDSecure (~> 5.6.1)
+    - Braintree/UnionPay (~> 5.6.1)
+    - Braintree/Venmo (~> 5.6.1)
   - Flutter (1.0.0)
   - flutter_braintree (1.0.0):
-    - Braintree/ApplePay (~> 5.3.2)
-    - Braintree/PayPal (~> 5.3.2)
-    - BraintreeDropIn (= 9.0.2)
+    - Braintree/ApplePay (~> 5.6.3)
+    - Braintree/PayPal (~> 5.6.3)
+    - BraintreeDropIn (= 9.4.0)
     - Flutter
 
 DEPENDENCIES:
@@ -49,11 +49,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_braintree/ios"
 
 SPEC CHECKSUMS:
-  Braintree: d9314d1a97acda74b77e40be5db6aa3e655c6539
-  BraintreeDropIn: 3e666d341e34efb0b5e18221eacd76db469bdab8
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_braintree: fe1bf2f5e99010e293af6986bc55876362bb28dd
+  Braintree: cef7388a3647515f1e0861e52200c2f3dad0f98f
+  BraintreeDropIn: 89df35f840004affa22ebb8f06b12d20615411bf
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  flutter_braintree: 72276002464c36b1d5a6266fbdb94c0b600e62fd
 
 PODFILE CHECKSUM: 4e8f8b2be68aeea4c0d5beb6ff1e79fface1d048
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -163,11 +163,12 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = G22XQ83JAR;
 						LastSwiftMigration = 0910;
 					};
 				};
@@ -373,6 +374,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = G22XQ83JAR;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -508,6 +510,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = G22XQ83JAR;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -536,6 +539,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
+				DEVELOPMENT_TEAM = G22XQ83JAR;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1250"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -17,7 +17,7 @@ import Braintree
         if url.scheme == "com.example.flutterBraintreeExample.payments" {
             return BTAppContextSwitcher.handleOpenURL(url)
         }
-        
+
         return false
     }
 

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -18,7 +18,7 @@ import Braintree
             return BTAppContextSwitcher.handleOpenURL(url)
         }
 
-        return false
+        return super.application(app, open: url, options:  options);
     }
 
 }

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -54,5 +54,7 @@
 			</array>
 		</dict>
 	</array>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -50,6 +50,19 @@ class _MyAppState extends State<MyApp> {
                 var request = BraintreeDropInRequest(
                   tokenizationKey: tokenizationKey,
                   collectDeviceData: true,
+                  requestThreeDSecureVerification: true,
+                  email: "test@email.com",
+                  billingAddress: BraintreeBillingAddress(
+                    givenName: "Jill",
+                    surname: "Doe",
+                    phoneNumber: "5551234567",
+                    streetAddress: "555 Smith St",
+                    extendedAddress: "#2",
+                    locality: "Chicago",
+                    region: "IL",
+                    postalCode: "12345",
+                    countryCodeAlpha2: "US",
+                  ),
                   googlePaymentRequest: BraintreeGooglePaymentRequest(
                     totalPrice: '4.20',
                     currencyCode: 'USD',

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,28 +21,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -56,7 +49,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -80,21 +73,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -127,35 +127,28 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "0.4.12"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.10.0"

--- a/ios/Classes/FlutterBraintreeDropInPlugin.swift
+++ b/ios/Classes/FlutterBraintreeDropInPlugin.swift
@@ -60,37 +60,35 @@ public class FlutterBraintreeDropInPlugin: BaseFlutterBraintreePlugin, FlutterPl
             isHandlingResult = true
             
             let threeDSecureRequest = BTThreeDSecureRequest()
-            threeDSecureRequest.nonce = tokenizedCard.nonce
-            if let email = dict(for: "email", in: call) {
+
+            if let email = string(for: "email", in: call) {
                 threeDSecureRequest.email = email
             }
             threeDSecureRequest.versionRequested = .version2
 
             if let billingAddress = dict(for: "billingAddress", in: call) {
                 let address = BTThreeDSecurePostalAddress()
-                address.givenName = billingAddress["givenName"]// ASCII-printable characters required, else will throw a validation error
-                address.surname = billingAddress["surname"] // ASCII-printable characters required, else will throw a validation error
-                address.phoneNumber = billingAddress["phoneNumber"]
-                address.streetAddress = billingAddress["streetAddress"]
-                address.extendedAddress = billingAddress["extendedAddress"]
-                address.locality = billingAddress["locality"]
-                address.region = billingAddress["region"]
-                address.postalCode = billingAddress["postalCode"]
-                address.countryCodeAlpha2 = billingAddress["countryCodeAlpha2"]
+                address.givenName = billingAddress["givenName"] as? String;
+                address.surname = billingAddress["surname"] as? String;
+                address.phoneNumber = billingAddress["phoneNumber"] as? String;
+                address.streetAddress = billingAddress["streetAddress"] as? String;
+                address.extendedAddress = billingAddress["extendedAddress"] as? String;
+                address.locality = billingAddress["locality"] as? String;
+                address.region = billingAddress["region"] as? String;
+                address.postalCode = billingAddress["postalCode"] as? String;
+                address.countryCodeAlpha2 = billingAddress["countryCodeAlpha2"] as? String;
                 threeDSecureRequest.billingAddress = address
+
+                // Optional additional information.
+                // For best results, provide as many of these elements as possible.
+                let info = BTThreeDSecureAdditionalInformation()
+                info.shippingAddress = address
+                threeDSecureRequest.additionalInformation = info
             }
-
-
-            // Optional additional information.
-            // For best results, provide as many of these elements as possible.
-            let info = BTThreeDSecureAdditionalInformation()
-            info.shippingAddress = address
-            threeDSecureRequest.additionalInformation = info
             
             let dropInRequest = BTDropInRequest()
             
             if let amount = string(for: "amount", in: call) {
-                let threeDSecureRequest = BTThreeDSecureRequest()
                 threeDSecureRequest.threeDSecureRequestDelegate = self
                 threeDSecureRequest.amount = NSDecimalNumber(string: amount)
                 dropInRequest.threeDSecureRequest = threeDSecureRequest

--- a/ios/Classes/FlutterBraintreeDropInPlugin.swift
+++ b/ios/Classes/FlutterBraintreeDropInPlugin.swift
@@ -59,6 +59,34 @@ public class FlutterBraintreeDropInPlugin: BaseFlutterBraintreePlugin, FlutterPl
             
             isHandlingResult = true
             
+            let threeDSecureRequest = BTThreeDSecureRequest()
+            threeDSecureRequest.nonce = tokenizedCard.nonce
+            if let email = dict(for: "email", in: call) {
+                threeDSecureRequest.email = email
+            }
+            threeDSecureRequest.versionRequested = .version2
+
+            if let billingAddress = dict(for: "billingAddress", in: call) {
+                let address = BTThreeDSecurePostalAddress()
+                address.givenName = billingAddress["givenName"]// ASCII-printable characters required, else will throw a validation error
+                address.surname = billingAddress["surname"] // ASCII-printable characters required, else will throw a validation error
+                address.phoneNumber = billingAddress["phoneNumber"]
+                address.streetAddress = billingAddress["streetAddress"]
+                address.extendedAddress = billingAddress["extendedAddress"]
+                address.locality = billingAddress["locality"]
+                address.region = billingAddress["region"]
+                address.postalCode = billingAddress["postalCode"]
+                address.countryCodeAlpha2 = billingAddress["countryCodeAlpha2"]
+                threeDSecureRequest.billingAddress = address
+            }
+
+
+            // Optional additional information.
+            // For best results, provide as many of these elements as possible.
+            let info = BTThreeDSecureAdditionalInformation()
+            info.shippingAddress = address
+            threeDSecureRequest.additionalInformation = info
+            
             let dropInRequest = BTDropInRequest()
             
             if let amount = string(for: "amount", in: call) {

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -3,6 +3,8 @@ class BraintreeDropInRequest {
     this.clientToken,
     this.tokenizationKey,
     this.amount,
+    this.billingAddress,
+    this.email,
     this.collectDeviceData = false,
     this.requestThreeDSecureVerification = false,
     this.googlePaymentRequest,

--- a/lib/src/request.dart
+++ b/lib/src/request.dart
@@ -24,8 +24,14 @@ class BraintreeDropInRequest {
   /// Either [clientToken] or [tokenizationKey] must be set.
   String? tokenizationKey;
 
+  ///Additional Information about the user to trigger 3ds 2.0
+  BraintreeBillingAddress? billingAddress;
+
   /// Amount for the transaction. This is only used for 3D secure verfications.
   String? amount;
+
+  /// Email of the user. this is used to icnrease the possibilities of success of 3ds 2.0
+  String? email;
 
   /// Whether the Drop-in should collect and return device data for fraud prevention.
   bool collectDeviceData;
@@ -67,6 +73,8 @@ class BraintreeDropInRequest {
   Map<String, dynamic> toJson() => {
         if (clientToken != null) 'clientToken': clientToken,
         if (tokenizationKey != null) 'tokenizationKey': tokenizationKey,
+        if (email != null) 'email': email,
+        if (billingAddress != null) 'billingAddress': billingAddress!.toJson(),
         if (amount != null) 'amount': amount,
         'collectDeviceData': collectDeviceData,
         'requestThreeDSecureVerification': requestThreeDSecureVerification,
@@ -81,6 +89,41 @@ class BraintreeDropInRequest {
         'maskCardNumber': maskCardNumber,
         'maskSecurityCode': maskSecurityCode,
         'vaultManagerEnabled': vaultManagerEnabled,
+      };
+}
+
+class BraintreeBillingAddress {
+  final String? givenName;
+  final String? surname;
+  final String? phoneNumber;
+  final String? streetAddress;
+  final String? extendedAddress;
+  final String? locality;
+  final String? region;
+  final String? postalCode;
+  final String? countryCodeAlpha2;
+
+  BraintreeBillingAddress(
+      {this.givenName,
+      this.surname,
+      this.phoneNumber,
+      this.streetAddress,
+      this.extendedAddress,
+      this.locality,
+      this.region,
+      this.postalCode,
+      this.countryCodeAlpha2});
+
+  Map<String, dynamic> toJson() => {
+        'givenName': givenName,
+        'surname': surname,
+        'phoneNumber': phoneNumber,
+        'streetAddress': streetAddress,
+        'extendedAddress': extendedAddress,
+        'locality': locality,
+        'region': region,
+        'postalCode': postalCode,
+        'countryCodeAlpha2': countryCodeAlpha2
       };
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,45 +7,45 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
     version: "0.0.99"
-  typed_data:
-    dependency: transitive
-    description:
-      name: typed_data
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=1.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_braintree
 description: Flutter plugin that wraps the native Braintree SDKs. Enables payments with credit cards, PayPal, Google Pay and more.
-version: 3.0.0-dev.1
+version: 2.3.2
 homepage: https://github.com/pikaju/flutter-braintree
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_braintree
 description: Flutter plugin that wraps the native Braintree SDKs. Enables payments with credit cards, PayPal, Google Pay and more.
-version: 2.3.2
+version: 2.3.3
 homepage: https://github.com/pikaju/flutter-braintree
 
 environment:


### PR DESCRIPTION
> In mid-October 2022, 3DS 1.0 will be officially deprecated by all major card providers, making EMV 3DS (commonly called 3DS 2.0) the new standard in 3D Secure authentication protocol.
> https://www.paypal.com/uk/smarthelp/article/faq4728

This PR edit the package to follow the guide to ensure best chances of success with 3DS 2.0 as stated here
https://developer.paypal.com/braintree/docs/guides/3d-secure/migration

It adds the model `BraintreeBillingAddress` and the parameter `email` and  `billingAddress `to the `BraintreeDropInRequest` 