### PR TITLE
Update drop-in sdk to 6.13.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.braintreepayments.api:drop-in:6.8.0'
+    implementation 'com.braintreepayments.api:drop-in:6.13.0'
     implementation 'com.google.android.gms:play-services-wallet:16.0.0'
     implementation 'androidx.appcompat:appcompat:1.4.0-alpha03'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'


### PR DESCRIPTION
In order to mitigate the following PlayStore issue https://github.com/braintree/braintree-android-drop-in/issues/452 that can lead to your app being removed, we need to upgrade the native SDK.

This upgrades a bunch of stuff including the browser-switch dependency. Which in a newer version does not have the BrowserSwitchActivity anymore but by using the Custom Activity from this plugin, everything still works for me